### PR TITLE
set up Gitlab CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,10 +1,16 @@
 before_script:
     - python3.5 -m venv buildenv
     - source buildenv/bin/activate
-    - pip install -v -r requirements.txt
+    - pip install -r requirements.txt
 
 test:
   script:
     - ./build.sh -v --debug
     - python tools/featuretest.py -g source/GlyphOrderAndAliasDB.txt test/test.json build/ScopeOne_Rg.ttf
-    - scp -r build evergreen:/mnt/RAID/gitlab-builds/ScopeOne-$(git rev-parse --short=7 HEAD)/
+    - CURR_REV=$(git rev-parse --short=7 HEAD)
+    - BUILD_TEMPDIR=$(echo build/build-*)
+    - mv $BUILD_TEMPDIR build/build-$CURR_REV
+    - cd build
+    - zip -qr build-$CURR_REV.zip build-$CURR_REV
+    - rm -rf build-$CURR_REV
+    - scp -r . evergreen:/mnt/RAID/gitlab-builds/ScopeOne-$CURR_REV/

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,9 +1,11 @@
-test:
-  stage: build
-  script:
+before_script:
     - python3.5 -m virtualenv buildenv
     - source buildenv/bin/activate
     - pip install -v -r requirements.txt
+
+test:
+  stage: build
+  script:
     - python3.5 build.py -v --debug --output-dir build source/ScopeOne_Rg.ufo
 
 staging:
@@ -12,8 +14,5 @@ staging:
     - master
     - gitlab-ci
   script:
-    - python3.5 -m virtualenv buildenv
-    - source buildenv/bin/activate
-    - pip install -v -r requirements.txt
     - python3.5 build.py -v --debug --output-dir build source/ScopeOne_Rg.ufo
     - scp -r build evergreen:/mnt/RAID/gitlab-builds/ScopeOne-$(git rev-parse --short=7 HEAD)/

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,18 +1,10 @@
 before_script:
-    - python3.5 -m virtualenv buildenv
+    - python3.5 -m venv buildenv
     - source buildenv/bin/activate
     - pip install -v -r requirements.txt
 
 test:
-  stage: build
   script:
-    - python3.5 build.py -v --debug --output-dir build source/ScopeOne_Rg.ufo
-
-staging:
-  stage: deploy
-  only:
-    - master
-    - gitlab-ci
-  script:
-    - python3.5 build.py -v --debug --output-dir build source/ScopeOne_Rg.ufo
+    - ./build.sh -v --debug
+    - python tools/featuretest.py -g source/GlyphOrderAndAliasDB.txt test/test.json build/ScopeOne_Rg.ttf
     - scp -r build evergreen:/mnt/RAID/gitlab-builds/ScopeOne-$(git rev-parse --short=7 HEAD)/

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,19 @@
+test:
+  stage: build
+  script:
+    - python3.5 -m virtualenv buildenv
+    - source buildenv/bin/activate
+    - pip install -v -r requirements.txt
+    - python3.5 build.py -v --debug --output-dir build source/ScopeOne_Rg.ufo
+
+staging:
+  stage: deploy
+  only:
+    - master
+    - gitlab-ci
+  script:
+    - python3.5 -m virtualenv buildenv
+    - source buildenv/bin/activate
+    - pip install -v -r requirements.txt
+    - python3.5 build.py -v --debug --output-dir build source/ScopeOne_Rg.ufo
+    - scp -r build evergreen:/mnt/RAID/gitlab-builds/ScopeOne-$(git rev-parse --short=7 HEAD)/


### PR DESCRIPTION
This sets up continuous integration with the internal Gitlab server.
At any push, the font will be compiled and uploaded, along with temporary build files, to a folder on the internal SFTP server.
