### PR TITLE
change fontinfo.plist for upcoming version 1.001; freeze requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@
 -e git+https://github.com/daltonmaag/ufo2fdk.git@76e8516744e2b8738477335924453ef8a4a96f83#egg=ufo2fdk
 
 # ufo2ft (from ufo2ft-dama branch on DaMa fork)
--e git+https://github.com/daltonmaag/ufo2fdk.git@4bdda79d6203e334ab37545d16cf6223435a517d#egg=ufo2ft
+-e git+https://github.com/daltonmaag/ufo2fdk.git@60f67ee3d90853140f0ca6b2e7e15bd71930e507#egg=ufo2ft
 
 # robofab (from python3-ufo3-no-ufoLib branch on DaMa fork)
 -e git+https://github.com/daltonmaag/robofab.git@48337cb8f734c88c13574c1f121e33ce6ff1f6d7#egg=robofab

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,16 +8,16 @@
 -e git+https://github.com/daltonmaag/defcon.git@559c8f6bde1629d13f4e8a69e1f6f2494d977c32#egg=defcon
 
 # ufoLib (from master branch on DaMa fork, in sync with upstream)
--e git+https://github.com/daltonmaag/ufoLib.git#egg=ufoLib
+-e git+https://github.com/daltonmaag/ufoLib.git@744423d267120681e85ad4efb73ff8df919d3c45#egg=ufoLib
 
 # ufonormalizer (from master on DaMa fork, in sync with upstream)
--e git+https://github.com/daltonmaag/ufoNormalizer.git#egg=ufonormalizer
+-e git+https://github.com/daltonmaag/ufoNormalizer.git@abc8393c608fdc1687e02df49a06768ff3d4e02c#egg=ufonormalizer
 
 # ufo2fdk (from python3-ufo3 branch on DaMa fork)
 -e git+https://github.com/daltonmaag/ufo2fdk.git@76e8516744e2b8738477335924453ef8a4a96f83#egg=ufo2fdk
 
 # ufo2ft (from ufo2ft-dama branch on DaMa fork)
--e git+https://github.com/daltonmaag/ufo2fdk.git@17ffa040debe6b2071a0f34a081802feace70eb4#egg=ufo2ft
+-e git+https://github.com/daltonmaag/ufo2fdk.git@4bdda79d6203e334ab37545d16cf6223435a517d#egg=ufo2ft
 
 # robofab (from python3-ufo3-no-ufoLib branch on DaMa fork)
 -e git+https://github.com/daltonmaag/robofab.git@48337cb8f734c88c13574c1f121e33ce6ff1f6d7#egg=robofab

--- a/source/GlyphOrderAndAliasDB.txt
+++ b/source/GlyphOrderAndAliasDB.txt
@@ -137,7 +137,7 @@ uni20B4 hryvnia uni20B4
 uni20B5 cedi uni20B5
 uni20B9 rupeeindian uni20B9
 uni20BA liraturkish uni20BA
-bitcoin bitcoin uni20BF
+uni20BF bitcoin uni20BF
 asciicircum asciicircum uni005E
 plus plus uni002B
 minus minus uni2212

--- a/source/ScopeOne_Rg.ufo/fontinfo.plist
+++ b/source/ScopeOne_Rg.ufo/fontinfo.plist
@@ -45,9 +45,9 @@
 		<key>openTypeNamePreferredSubfamilyName</key>
 		<string>Regular</string>
 		<key>openTypeNameUniqueID</key>
-		<string>Scope One Regular Version 1.000</string>
+		<string>Scope One Regular Version 1.001</string>
 		<key>openTypeNameVersion</key>
-		<string>Version 1.000</string>
+		<string>Version 1.001</string>
 		<key>openTypeOS2CodePageRanges</key>
 		<array>
 			<integer>0</integer>
@@ -194,7 +194,7 @@
 		<key>versionMajor</key>
 		<integer>1</integer>
 		<key>versionMinor</key>
-		<integer>0</integer>
+		<integer>1</integer>
 		<key>xHeight</key>
 		<integer>500</integer>
 		<key>year</key>

--- a/tools/build.py
+++ b/tools/build.py
@@ -174,6 +174,10 @@ def build(ufopath, output_dir=None, formats=['cff'], goadb=None, debug=False,
             if goadb:
                 logging.info('Rename glyphs using "%s"' % goadb)
                 rename_glyphs(goadb, outfile)
+
+            # as of v1.4.1, ttfautohint modifies the table order. So here I
+            # restore the 'optimal' TrueType table order
+            TTFont(outfile).save(outfile, reorderTables=True)
         else:
             logging.info('Save font')
             otf.save(outfile)


### PR DESCRIPTION
this updates the version strings and font revision to 1.001.

All the Python dependencies are now freezed at specific commits in the `requirements.txt` file, so we can replicate the same output if we need to.