### PR TITLE
fix for SyntaxError: Non-ASCII character '\xc2' in file tools/build.py on line 227

### DIFF
--- a/tools/build.py
+++ b/tools/build.py
@@ -224,7 +224,7 @@ def parse_options(args):
                 not os.path.exists(os.path.join(ufopath, 'metainfo.plist'))):
             parser.error('Invalid UFO font: "%s"' % ufopath)
     if not options.formats:
-        # default to TTF/OTF output
+        # default to TTF/OTF output
         options.formats = ['ttf']
     else:
         # prune duplicate format entries


### PR DESCRIPTION
fix for SyntaxError: Non-ASCII character '\xc2' in file tools/build.py on line 227, but no encoding declared; see http://www.python.org/peps/pep-0263.html for details