### PR TITLE
build.py: Remove UTF+8 nbsp from comment

### DIFF
--- a/tools/build.py
+++ b/tools/build.py
@@ -224,7 +224,7 @@ def parse_options(args):
                 not os.path.exists(os.path.join(ufopath, 'metainfo.plist'))):
             parser.error('Invalid UFO font: "%s"' % ufopath)
     if not options.formats:
-        # default to TTF/OTF output
+        # default to TTF/OTF output
         options.formats = ['ttf']
     else:
         # prune duplicate format entries


### PR DESCRIPTION
Remove UTF-8 encoded \u00a0 nbsp from middle of Python comment in .py without explicit UTF-8 declared encoding.